### PR TITLE
Ensure changelog file exists even if empty

### DIFF
--- a/.github/workflows/errors.yml
+++ b/.github/workflows/errors.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: ⚙ openlaw
         run: |
+            New-Item -Path "${{ runner.temp }}/openlaw.md" -ItemType File -Force | Out-Null
             $dirs = gci .\.github\.openlaw -directory
             foreach ($dir in $dirs) {
                 $files = gci $dir.fullname -file


### PR DESCRIPTION
This fixes an issue with the PR step that fails otherwise if nothing was updated.
